### PR TITLE
Add a flag to disable "social share" links

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,9 @@ googleAnalytics = ""
     loadFavicon          = false
     faviconVersion       = ""
 
+    # Disable showing the social sharing links on blog posts
+    # socialShareDisabled = true
+
     # Load custom CSS or JavaScript files. This replaces the deprecated params
     # minifiedFilesCSS and minifiedFilesJS. The variable is an array so that you
     # can load multiple files if necessary. You can also load the standard theme

--- a/layouts/post/content-single.html
+++ b/layouts/post/content-single.html
@@ -1,11 +1,14 @@
 <article class="post">
     {{ .Render "header" }}
 
+    {{ if not .Site.Params.socialShareDisabled }}
     <section id="social-share">
         <ul class="icons">
             {{ partial "share-links" . }}
         </ul>
     </section>
+    {{ end }}
+
     {{ .Render "featured" }}
     <div id="content">
         {{ .Content }}


### PR DESCRIPTION
For blogs that don't want to be easily shared all over, make a flag
to hide the "social sharing" links at the top of a post.