### PR TITLE
Fix category url in category-footer.html

### DIFF
--- a/layouts/post/footer-category.html
+++ b/layouts/post/footer-category.html
@@ -15,6 +15,11 @@
 
                     {{ $.Scratch.Set "categoryUrl" $categoryMenu.URL }}
 
+                    <!-- Ensure that there is a trailing '/' in the category Url -->
+                    {{ if ne (substr ($.Scratch.Get "categoryUrl") (sub (len ($.Scratch.Get "categoryUrl")) 1)) "/" }}
+                        {{ $.Scratch.Set "categoryUrl" (add ($.Scratch.Get "categoryUrl") "/") }}
+                    {{ end }}
+
                     {{ with $categoryMenu.Identifier }}
                         <i class="{{ . }}">&nbsp;</i>
                     {{ end }}


### PR DESCRIPTION
Ensure that there is a trailing '/' in the category URL when using the
url defined for the menu item "Categories". Without this the template
produces invalid urls for the category links in the footer of the post
if the user has defined a menu item named "Categories" without a
trailing slash (as in the example page).