### PR TITLE
The valuable "customCSS" should be lowercase.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -44,7 +44,7 @@
              to keep the deprecated param. -->
         {{ if isset .Site.Params "minifiedFilesCSS" }}
             {{ $.Scratch.Set "cssFiles" .Site.Params.minifiedFilesCSS }}
-        {{ else if isset .Site.Params "customCSS" }}
+        {{ else if isset .Site.Params "customcss" }}
             {{ $.Scratch.Set "cssFiles" .Site.Params.customCSS }}
         {{ else }}
             {{ $.Scratch.Set "cssFiles" false }}


### PR DESCRIPTION
I found out that "customCSS" in "hugo-future-imperfect/exampleSite/config.toml" was not loaded.
According to the below page, all params should be changed lowercase.
https://gohugo.io/templates/variables/