### PR TITLE
Remove highlight js and use hugo shortcode instead

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -60,15 +60,6 @@ canonifyURLs = true
   customCSS            = ["default"]
   customJS             = ["default"]
 
-  # options for highlight.js (version, additional languages, and theme)
-  disable_highlight = false # set to true to disable Highlight
-  highlightjsVersion = "9.12.0"
-  highlightjsCDN = "https://cdnjs.cloudflare.com/ajax/libs"
-  highlightjsLang = ["r", "yaml", "css"]
-  highlightjsTheme = "github"
-  MathJaxCDN = "https://cdnjs.cloudflare.com/ajax/libs"
-  MathJaxVersion = "2.7.4"
-
 # Disqus will take priority over Staticman (github.com/eduardoboucas/staticman)
 # due to its ease of use. Feel free to check out both and decide what you would
 # prefer to use. See Staticman.yml for additional settings.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,19 +8,6 @@
       {{ $.Scratch.Set "jsFiles" false }}
     {{ end }}
 
-    {{ if (and (not .Site.Params.disable_highlight) (not .Params.disable_highlight)) }}
-        {{ $highVersion := .Site.Params.highlightjsVersion | default "9.12.0" }}
-        {{ $highCDN := .Site.Params.highlightjsCDN | default "https://cdnjs.cloudflare.com/ajax/libs" }}
-        <script src="{{ $highCDN }}/highlight.js/{{ $highVersion }}/highlight.min.js"></script>
-
-        {{ $.Scratch.Set "highLangs" .Site.Params.highlightjsLang }}
-        {{ range .Params.highlightjsLang }}{{ $.Scratch.Add "highLangs" . }}{{ end }}
-        {{ range ($.Scratch.Get "highLangs") }}
-          <script src="{{ $highCDN }}/highlight.js/{{ $highVersion }}/languages/{{ . }}.min.js"></script>
-        {{ end }}
-        <script>hljs.initHighlightingOnLoad();</script>
-    {{ end }}
-
     <!-- If the value "default" is passed into the param then we will first
      load the standard js files associated with the theme -->
     {{ if or (in ($.Scratch.Get "jsFiles") "default") (eq ($.Scratch.Get "jsFiles") false) }}
@@ -40,8 +27,5 @@
       {{ end }}
     {{ end }}
 
-    <!-- This is called by default since this theme uses highlight.js -->
-    <script>hljs.initHighlightingOnLoad();</script>
-      {{ partial "footer_mathjax" . }}
   </body>
 </html>

--- a/layouts/partials/footer_mathjax.html
+++ b/layouts/partials/footer_mathjax.html
@@ -1,3 +1,0 @@
-<script async
-src="{{ .Site.Params.MathJaxCDN | default "https://cdnjs.cloudflare.com/ajax/libs"}}/mathjax/{{ .Site.Params.MathJaxVersion }}/MathJax.js?config=TeX-MML-AM_CHTML">
-</script>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -66,13 +66,6 @@
             {{ end }}
         {{ end }}
 
-        {{ if (and (not .Site.Params.disable_highlight) (not .Params.disable_highlight)) }}
-            {{ $highTheme := .Site.Params.highlightjsTheme | default "github" }}
-            {{ $highVersion := .Site.Params.highlightjsVersion | default "9.12.0" }}
-            {{ $highCDN := .Site.Params.highlightjsCDN | default "//https://cdnjs.cloudflare.com/ajax/libs" }}
-            <link href='{{ $highCDN }}/highlight.js/{{ $highVersion }}/styles/{{ $highTheme }}.min.css' rel='stylesheet' type='text/css' />
-        {{ end }}
-
       {{ template "_internal/google_analytics.html" . }}
     </head>
     <body>

--- a/theme.toml
+++ b/theme.toml
@@ -6,7 +6,7 @@ license = "MIT"
 licenselink = "https://github.com/jpescador/hugo-future-imperfect/blob/master/LICENSE.md"
 description = "Ported theme of HTML5 UP, future imperfect, with some extra goodies"
 homepage = "https://github.com/jpescador/hugo-future-imperfect"
-tags = ["blog", "responsive", "font awesome", "highlight.js", "fancybox 3", "staticman", "netlify"]
+tags = ["blog", "responsive", "font awesome", "fancybox 3", "staticman", "netlify"]
 features = ["html5", "css3", "responsive"]
 min_version = 0.15
 


### PR DESCRIPTION
As suggested by @lfkeitel in upstream PR https://github.com/jpescador/hugo-future-imperfect/pull/135, I am going to use [hugo Shortcodes](https://gohugo.io/content-management/shortcodes/) instead. This PR also removes MathJax which I don't need currently.