### PR TITLE
Disable share in navbar

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 {{ partial "header" . }}
-    {{ $.Scratch.Set "shareNav" true }}
+    {{ $.Scratch.Set "shareNav" false }}
     {{ partial "navbar" . }}
     <!-- Main -->
     <div id="main">

--- a/layouts/itemized/single.html
+++ b/layouts/itemized/single.html
@@ -1,5 +1,5 @@
 {{ partial "header" . }}
-    {{ $.Scratch.Set "shareNav" true }}
+    {{ $.Scratch.Set "shareNav" false }}
     {{ partial "navbar" . }}
     {{ partial "share-menu" . }}
     <!-- Main -->

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,5 +1,5 @@
 {{ partial "header" . }}
-    {{ $.Scratch.Set "shareNav" true }}
+    {{ $.Scratch.Set "shareNav" false }}
     {{ partial "navbar" . }}
     {{ partial "share-menu" . }}
     <!-- Main -->


### PR DESCRIPTION
I don't need it and looks like it breaks my mobile UI so this is the fastest way I can find to disable it.